### PR TITLE
Category pages and category news fetch

### DIFF
--- a/app/Majandus/page.tsx
+++ b/app/Majandus/page.tsx
@@ -1,0 +1,16 @@
+import HomeHeader from "@/components/HomeHeader"
+import NewsArticlesMajandus from "@/components/NewsArticlesMajandus"
+import NewsSideFilters from "@/components/NewsSideFilters"
+
+export default function Majandus() {
+  return (
+    <main>
+      <HomeHeader />
+
+      <div className="flex flex-1 pt-8 w-[93%] mx-auto gap-10">
+        <NewsSideFilters />
+        <NewsArticlesMajandus />
+      </div>
+    </main>
+  )
+}

--- a/app/Sport/page.tsx
+++ b/app/Sport/page.tsx
@@ -1,0 +1,16 @@
+import HomeHeader from "@/components/HomeHeader"
+import NewsArticlesSport from "@/components/NewsArticlesSport"
+import NewsSideFilters from "@/components/NewsSideFilters"
+
+export default function Sport() {
+  return (
+    <main>
+      <HomeHeader />
+
+      <div className="flex flex-1 pt-8 w-[93%] mx-auto gap-10">
+        <NewsSideFilters />
+        <NewsArticlesSport />
+      </div>
+    </main>
+  )
+}

--- a/components/NewsArticles.tsx
+++ b/components/NewsArticles.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from 'react';
 import NewsDisplay from "./NewsDisplay"
 
 export default async function NewsArticles() {
@@ -8,7 +9,8 @@ export default async function NewsArticles() {
   */
   const newsdataApiKey = process.env.NEWSDATA_API_KEY!
   const fNews = await fetch(
-    `https://newsdata.io/api/1/news?country=ee&apikey=${newsdataApiKey}`
+    //`https://newsdata.io/api/1/news?country=ee&apikey=${newsdataApiKey}`
+    `https://newsdata.io/api/1/news?apikey=${newsdataApiKey}&language=et`
   )
   const pNews = await fNews.json()
 

--- a/components/NewsArticlesMajandus.tsx
+++ b/components/NewsArticlesMajandus.tsx
@@ -1,0 +1,23 @@
+import NewsDisplayMajandus from "./NewsDisplayMajandus"
+
+export default async function NewsArticlesMajandus() {
+  /*
+  ma tegin neid API calle veel yhe API-ga, et vaadata kas need funktsioonid toimivad, panen selle ka siia:
+  
+  NEWSDATA_API_KEY=pub_3560362c67f1305c7a3b58c00f87cbbef3955
+
+  URL: https://newsdata.io/api/1/news?apikey=pub_3560362c67f1305c7a3b58c00f87cbbef3955&language=et
+  */
+  const newsdataApiKey = process.env.NEWSDATA_API_KEY!
+  const fNews = await fetch(
+    `https://newsdata.io/api/1/news?country=ee&apikey=${newsdataApiKey}`
+  )
+  const pNews = await fNews.json()
+
+  return (
+    <div className="h-screen w-[80vh] bg-slate-300 rounded-xl px-4 py-4">
+      <p className="text-2xl text-black font-bold">Viimased uudised:</p>
+      <NewsDisplayMajandus news={pNews} />
+    </div>
+  )
+}

--- a/components/NewsArticlesSport.tsx
+++ b/components/NewsArticlesSport.tsx
@@ -1,0 +1,16 @@
+import NewsDisplaySport from "./NewsDisplaySport"
+
+export default async function NewsArticlesSport() {
+  const newsdataApiKey = process.env.NEWSDATA_API_KEY!
+  const fNews = await fetch(
+    `https://newsdata.io/api/1/news?country=ee&apikey=${newsdataApiKey}`
+  )
+  const pNews = await fNews.json()
+
+  return (
+    <div className="h-screen w-[80vh] bg-slate-300 rounded-xl px-4 py-4">
+      <p className="text-2xl text-black font-bold">Viimased uudised:</p>
+      <NewsDisplaySport news={pNews} />
+    </div>
+  )
+}

--- a/components/NewsDisplayMajandus.tsx
+++ b/components/NewsDisplayMajandus.tsx
@@ -1,0 +1,35 @@
+export default function NewsDisplayMajandus(props: { news: any }) {
+    const filterNewsByKeyword = (newsEntries: any[]) => {
+        return newsEntries.filter(newsEntry => {
+          const keywords = newsEntry.keywords;
+      
+            if (typeof keywords === 'string' && keywords.toLowerCase().includes("majandus")) {
+                return true;
+            } else if (Array.isArray(keywords) && keywords.some(keyword => typeof keyword === 'string' && keyword.toLowerCase().includes("majandus"))) {
+                return true;
+            }
+          return false;
+        });
+    };
+
+    const filteredNews = filterNewsByKeyword(props.news.results);
+  
+    const newsInList = filteredNews.map(newsEntry => {
+      return (
+        <div
+          className="border-solid rounded border-8 my-8 text-black border-red-900 p-2"
+          key={newsEntry.article_id}
+        >
+          <a href={newsEntry.link} className="font-bold">
+            {newsEntry.title}
+          </a>
+          <p>{newsEntry.description}</p>
+        </div>
+      );
+    });
+  
+    return (
+      <ul className="overflow-hidden overflow-y-scroll h-[97%]">{newsInList}</ul>
+    );
+  }
+  

--- a/components/NewsDisplaySport.tsx
+++ b/components/NewsDisplaySport.tsx
@@ -1,0 +1,35 @@
+export default function NewsDisplaySport(props: { news: any }) {
+    const filterNewsByKeyword = (newsEntries: any[]) => {
+        return newsEntries.filter(newsEntry => {
+          const keywords = newsEntry.keywords;
+      
+            if (typeof keywords === 'string' && keywords.toLowerCase().includes("sport")) {
+                return true;
+            } else if (Array.isArray(keywords) && keywords.some(keyword => typeof keyword === 'string' && keyword.toLowerCase().includes("sport"))) {
+                return true;
+            }
+          return false;
+        });
+    };
+
+    const filteredNews = filterNewsByKeyword(props.news.results);
+  
+    const newsInList = filteredNews.map(newsEntry => {
+      return (
+        <div
+          className="border-solid rounded border-8 my-8 text-black border-red-900 p-2"
+          key={newsEntry.article_id}
+        >
+          <a href={newsEntry.link} className="font-bold">
+            {newsEntry.title}
+          </a>
+          <p>{newsEntry.description}</p>
+        </div>
+      );
+    });
+  
+    return (
+      <ul className="overflow-hidden overflow-y-scroll h-[97%]">{newsInList}</ul>
+    );
+  }
+  


### PR DESCRIPTION
Siin on ka veitsa sinu abi vaja, kuna vaatasin, et sa olid HomeHeaderis NavigationBar funktsiooni muutnud ja ma ei saand neid kategooria linke läbi "href" attribuudi kuvada, kui vajutada headeris nuppudele, seega tegin eraldi folderid Majandus ja Sport ja viskasin sinna sisse page ja siis toimis. (tean, et not the best approach).
Teiseks ma veel ei suutnud seda category fetchi päris korralikult teha seega on iga page jaoks 2 eraldi funktsiooni (DisplayMajandus ja ArticlesMajandus). Selle saab kunagi refactoriga korda teha.
Ma tegin ise ka NewsData kaudu uue API fetch lingi, millega saad ka testida kui soovid - peaks olema ArticlesMajanduses kirjas.